### PR TITLE
Minor Updates to installation and instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Rename this file to .env and fill in your API keys
+# Get Groq API key from https://console.groq.com/docs/quickstart
+GROQ_API_KEY=

--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ Understand the flow of ideas in a document broken into paragraphs.
    pip install -r requirements.txt
    ```
 
+3. **Set up Environment Variables**
+   ```bash
+   cp .env.example .env
+   ```
+   Then edit the `.env` file and fill in your API keys:
+   ```
+   GROQ_API_KEY=your_groq_api_key_here
+   ```
+   You can obtain the necessary API keys from:
+   - Groq API key: [Groq docs quickstart](https://console.groq.com/docs/quickstart)
+
 ### Usage
 
 1. In `src/summarize.py`, add the file name and type, for example:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,6 @@
 cloud_provider: "groq" #"ollama"
 llm_provider: "groq" #"ollama"
-llm_model: "llama-3.2-90b-text-preview" #gemma:2b"
+llm_model: "llama-3.1-70b-versatile" #gemma:2b"
 embedding_model: "nomic-embed-text:latest"
 
 token_limit: 1000

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,6 +58,7 @@ langchain-community==0.3.5
 langchain-core>=0.3.15
 langchain-groq==0.2.1
 langchain-ollama
+langchain-openai
 langchain-huggingface
 langchain-text-splitters==0.3.2
 langsmith>=0.1.125


### PR DESCRIPTION
Added python package()s) missing while installing; updated README instructions to get API keys; updated llama model that got deprecated in Groq to another suggested llama model

1. While installing the repo, I got the following error:
```
ModuleNotFoundError: No module named 'langchain_openai'
```
Installed the package `langchain_openai`, and added to `requirements.txt`

The version which is installed in my computer is:
`langchain_openai==0.2.12`

2.  ```The model llama-3.2-90b-text-preview has been deprecated```
https://console.groq.com/docs/deprecations

Recommended Replacement Models (given in [Groq page](https://console.groq.com/docs/deprecations):
llama-3.2-90b-vision-preview
llama-3.1-70b-versatile (text-only workloads)
I have replaced with `llama-3.1-70b-versatile` since for now the project is text based.
We can consider `llama-3.2-90b-vision-preview` when required.

3. `GROQ_API_KEY` environment variable needs to be set.
I have added `.env.example` file, which users needs to rename to `.env`.

```
groq.GroqError: The api_key client option must be set either by passing api_key to the client or by setting in environment file.
```
We can add other API key variables also in this `.env.example` file which users need to set.

4. Instructions to install Ollama needs to be added. Adding that part of next PR.