### PR TITLE
Updates to installation and instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 # Rename this file to .env and fill in your API keys
 # Get Groq API key from https://console.groq.com/docs/quickstart
 GROQ_API_KEY=
+
+# Get OpenAI API key from https://platform.openai.com/docs/quickstart
+OPENAI_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Rename this file to .env and fill in your API keys
+# Get Groq API key from https://console.groq.com/docs/quickstart
+GROQ_API_KEY=

--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ Understand the flow of ideas in a document broken into paragraphs.
    pip install -r requirements.txt
    ```
 
+3. **Set up Environment Variables**
+   ```bash
+   cp .env.example .env
+   ```
+   Then edit the `.env` file and fill in your API keys:
+   ```
+   GROQ_API_KEY=your_groq_api_key_here
+   ```
+   You can obtain the necessary API keys from:
+   - Groq API key: [Groq docs quickstart](https://console.groq.com/docs/quickstart)
+
 ### Usage
 
 1. In `src/summarize.py`, add the file name and type, for example:

--- a/README.md
+++ b/README.md
@@ -65,16 +65,42 @@ Understand the flow of ideas in a document broken into paragraphs.
    pip install -r requirements.txt
    ```
 
-3. **Set up Environment Variables**
-   ```bash
-   cp .env.example .env
-   ```
-   Then edit the `.env` file and fill in your API keys:
-   ```
-   GROQ_API_KEY=your_groq_api_key_here
-   ```
-   You can obtain the necessary API keys from:
-   - Groq API key: [Groq docs quickstart](https://console.groq.com/docs/quickstart)
+3. **Install and Configure Model Providers**
+
+   The tool supports multiple model providers. Choose and set up at least one:
+
+   **Option A: Ollama (Local)**
+   1. Install Ollama by following instructions at [Ollama.ai](https://ollama.ai)
+   2. Pull required models:
+      ```bash
+      # For LLM
+      ollama pull gemma:2b  # or your preferred model
+
+      # For embeddings
+      ollama pull nomic-embed-text
+      ```
+   3. Update `config/config.yaml`:
+      ```yaml
+      cloud_provider: "ollama"
+      llm_provider: "ollama"
+      llm_model: "gemma:2b"  # or your chosen model
+      embedding_model: "nomic-embed-text:latest"
+      ```
+
+   **Option B: Groq (Cloud)**
+   1. Sign up for a Groq account and get your API key
+   2. Set your Groq API key:
+      ```bash
+      export GROQ_API_KEY="your-api-key"
+      ```
+      or add the key in `.env` file.
+   3. Update `config/config.yaml`:
+      ```yaml
+      cloud_provider: "groq"
+      llm_provider: "groq"
+      llm_model: "llama-3.1-70b-versatile"
+      embedding_model: "nomic-embed-text:latest"
+      ```
 
 ### Usage
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,6 @@
 cloud_provider: "groq" #"ollama"
 llm_provider: "groq" #"ollama"
-llm_model: "llama-3.2-90b-text-preview" #gemma:2b"
+llm_model: "llama-3.1-70b-versatile" #gemma:2b"
 embedding_model: "nomic-embed-text:latest"
 
 token_limit: 1000

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,7 +1,7 @@
 cloud_provider: "groq" #"ollama"
 llm_provider: "groq" #"ollama"
-llm_model: "llama-3.1-70b-versatile" #gemma:2b"
-embedding_model: "nomic-embed-text:latest"
+llm_model: "llama-3.1-70b-versatile" #"gemma:2b"
+embedding_model: "text-embedding-ada-002" #"nomic-embed-text:latest" for ollama
 
 token_limit: 1000
 target_words: 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,6 +58,7 @@ langchain-community==0.3.5
 langchain-core>=0.3.15
 langchain-groq==0.2.1
 langchain-ollama
+langchain-openai
 langchain-huggingface
 langchain-text-splitters==0.3.2
 langsmith>=0.1.125

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -3,10 +3,9 @@ import yaml
 import logging
 from dotenv import load_dotenv
 from langchain_groq import ChatGroq
-from langchain_community.embeddings import OllamaEmbeddings
-from langchain_ollama import ChatOllama
+from langchain_ollama import ChatOllama, OllamaEmbeddings
 from langchain_openai import OpenAI
-from langchain_openai import AzureOpenAI
+from langchain_openai import AzureOpenAI, OpenAIEmbeddings
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -121,13 +120,22 @@ class ModelManager:
 
     def load_embedding_model(self):
         """
-        Lazily loads the Hugging Face embedding model based on the configuration if it hasn't been loaded yet.
+        Lazily Loads the embedding model based on the cloud provider configuration. if it hasn't been loaded yet.
         :return: The loaded embedding model.
         """
         if not self.embedding_model:
             try:
                 logger.info("Loading embedding model...")
-                self.embedding_model = OllamaEmbeddings(model=self.config['embedding_model'])
+                if self.config['cloud_provider'] == 'ollama':
+                    self.embedding_model = OllamaEmbeddings(
+                        model=self.config['embedding_model']
+                    )
+                elif self.config['cloud_provider'] == 'groq':
+                    # Since Groq doesn't have embeddings yet, we'll use OpenAI's
+                    self.embedding_model = OpenAIEmbeddings(
+                        model=self.config['embedding_model']
+                    )
+
                 logger.info("Embedding model loaded successfully.")
             except KeyError as e:
                 logger.error("Missing required config key for embedding model: %s", e)


### PR DESCRIPTION
Added python package()s) missing while installing; updated README instructions to get API keys; updated llama model that got deprecated in Groq to another suggested llama model

1. While installing the [BrahmaSumm repo](https://github.com/balajivis/BrahmaSumm-Community-Edition/), I got the following error:
```
ModuleNotFoundError: No module named 'langchain_openai'
```
Installed the package `langchain_openai`, and added to `requirements.txt`

The version which is installed in my computer is:
`langchain_openai==0.2.12`

2.  ```The model llama-3.2-90b-text-preview has been deprecated```
https://console.groq.com/docs/deprecations

Recommended Replacement Models (given in [Groq page](https://console.groq.com/docs/deprecations):
llama-3.2-90b-vision-preview
llama-3.1-70b-versatile (text-only workloads)
I have replaced with `llama-3.1-70b-versatile` since for now the project is text based.
We can consider `llama-3.2-90b-vision-preview` when required.

![Screenshot 2024-12-18 at 5 48 44 PM](https://github.com/user-attachments/assets/06abbd6b-18d1-4be9-9909-d4b1ba0df7f8)


3. Added Instructions Install and Configure Model Providers - Ollama and Groq.

4. `GROQ_API_KEY` environment variable needs to be set.
I have added `.env.example` file, which users needs to rename to `.env`.

```
groq.GroqError: The api_key client option must be set either by passing api_key to the client or by setting in environment file.
```
We can add other API key variables also in this `.env.example` file which users need to set.

5. `src/summarize.py` was using `OllamaEmbeddings` even if run in `Groq` config setting. Updated to use `OpenAIEmbedding` if running in `Groq` setting. I think that maybe the expected behavior. Pls let me know otherwise.

